### PR TITLE
Bugfix: support set up tear down

### DIFF
--- a/lib/nodeunit.js
+++ b/lib/nodeunit.js
@@ -16,7 +16,7 @@ nodeunit = (function(){
 
     Public Domain.
 
-    NO WARRANTY EXBrowser-based test reporterPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
     See http://www.JSON.org/js.html
 
@@ -577,13 +577,18 @@ var reporter = {};
     //// exported async module functions ////
 
     //// nextTick implementation with browser-compatible fallback ////
-    if (typeof process === 'undefined' || !(process.nextTick)) {
+    if (typeof setImmediate === 'function') {
+        async.nextTick = function (fn) {
+            setImmediate(fn);
+        };
+    }
+    else if (typeof process !== 'undefined' && process.nextTick) {
+        async.nextTick = process.nextTick;
+    }
+    else {
         async.nextTick = function (fn) {
             setTimeout(fn, 0);
         };
-    }
-    else {
-        async.nextTick = process.nextTick;
     }
 
     async.forEach = function (arr, iterator, callback) {
@@ -1281,6 +1286,17 @@ assert.deepEqual = function deepEqual(actual, expected, message) {
   }
 };
 
+var Buffer = null;
+if (typeof require !== 'undefined' && typeof process !== 'undefined') {
+    try {
+        Buffer = require('buffer').Buffer;
+    }
+    catch (e) {
+        // May be a CommonJS environment other than Node.js
+        Buffer = null;
+    }
+}
+
 function _deepEqual(actual, expected) {
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {
@@ -1290,6 +1306,25 @@ function _deepEqual(actual, expected) {
   } else if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
 
+  // 7.2.1 If the expcted value is a RegExp object, the actual value is
+  // equivalent if it is also a RegExp object that refers to the same source and options
+  } else if (actual instanceof RegExp && expected instanceof RegExp) {
+    return actual.source === expected.source &&
+           actual.global === expected.global &&
+           actual.ignoreCase === expected.ignoreCase &&
+           actual.multiline === expected.multiline;
+
+  } else if (Buffer && actual instanceof Buffer && expected instanceof Buffer) {
+    return (function() {
+      var i, len;
+
+      for (i = 0, len = expected.length; i < len; i++) {
+        if (actual[i] !== expected[i]) {
+          return false;
+        }
+      }
+      return actual.length === expected.length;
+    })();
   // 7.3. Other pairs that do not both pass typeof value == "object",
   // equivalence is determined by ==.
   } else if (typeof actual != 'object' && typeof expected != 'object') {
@@ -1384,47 +1419,52 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
-function _throws (shouldThrow, block, err, message) {
-  var exception = null,
-      threw = false,
-      typematters = true;
+function expectedException(actual, expected) {
+  if (!actual || !expected) {
+    return false;
+  }
 
-  message = message || "";
+  if (expected instanceof RegExp) {
+    return expected.test(actual.message || actual);
+  } else if (actual instanceof expected) {
+    return true;
+  } else if (expected.call({}, actual) === true) {
+    return true;
+  }
 
-  //handle optional arguments
-  if (arguments.length == 3) {
-    if (typeof(err) == "string") {
-      message = err;
-      typematters = false;
-    }
-  } else if (arguments.length == 2) {
-    typematters = false;
+  return false;
+}
+
+function _throws(shouldThrow, block, expected, message) {
+  var actual;
+
+  if (typeof expected === 'string') {
+    message = expected;
+    expected = null;
   }
 
   try {
     block();
   } catch (e) {
-    threw = true;
-    exception = e;
+    actual = e;
   }
 
-  if (shouldThrow && !threw) {
-    fail( "Missing expected exception"
-        + (err && err.name ? " ("+err.name+")." : '.')
-        + (message ? " " + message : "")
-        );
+  message = (expected && expected.name ? ' (' + expected.name + ').' : '.') +
+            (message ? ' ' + message : '.');
+
+  if (shouldThrow && !actual) {
+    fail('Missing expected exception' + message);
   }
-  if (!shouldThrow && threw && typematters && exception instanceof err) {
-    fail( "Got unwanted exception"
-        + (err && err.name ? " ("+err.name+")." : '.')
-        + (message ? " " + message : "")
-        );
+
+  if (!shouldThrow && expectedException(actual, expected)) {
+    fail('Got unwanted exception' + message);
   }
-  if ((shouldThrow && threw && typematters && !(exception instanceof err)) ||
-      (!shouldThrow && threw)) {
-    throw exception;
+
+  if ((shouldThrow && actual && expected &&
+      !expectedException(actual, expected)) || (!shouldThrow && actual)) {
+    throw actual;
   }
-};
+}
 
 // 11. Expected to throw an error:
 // assert.throws(block, Error_opt, message_opt);
@@ -1447,8 +1487,7 @@ assert.ifError = function (err) { if (err) {throw err;}};
  * MIT Licensed
  *
  * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
- * You can use @REMOVE_LINE_FOR_BROWSER to remove code from the browser build.
- * Only code on that line will be removed, its mostly to avoid requiring code
+ * Only code on that line will be removed, it's mostly to avoid requiring code
  * that is node specific
  */
 
@@ -1456,8 +1495,6 @@ assert.ifError = function (err) { if (err) {throw err;}};
  * Module dependencies
  */
 
-//var assert = require('./assert'),     //@REMOVE_LINE_FOR_BROWSER
-//    async = require('../deps/async'); //@REMOVE_LINE_FOR_BROWSER
 
 
 /**
@@ -1511,7 +1548,7 @@ exports.assertionList = function (arr, duration) {
 
 /**
  * Create a wrapper function for assert module methods. Executes a callback
- * after the it's complete with an assertion object representing the result.
+ * after it's complete with an assertion object representing the result.
  *
  * @param {Function} callback
  * @api private
@@ -1638,8 +1675,7 @@ exports.options = function (opt) {
  * MIT Licensed
  *
  * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
- * You can use @REMOVE_LINE_FOR_BROWSER to remove code from the browser build.
- * Only code on that line will be removed, its mostly to avoid requiring code
+ * Only code on that line will be removed, it's mostly to avoid requiring code
  * that is node specific
  */
 
@@ -1647,8 +1683,6 @@ exports.options = function (opt) {
  * Module dependencies
  */
 
-//var async = require('../deps/async'), //@REMOVE_LINE_FOR_BROWSER
-//    types = require('./types');       //@REMOVE_LINE_FOR_BROWSER
 
 
 /**
@@ -1722,26 +1756,28 @@ exports.runTest = function (name, fn, opt, callback) {
  */
 
 exports.runSuite = function (name, suite, opt, callback) {
+    suite = wrapGroup(suite);
     var keys = _keys(suite);
 
     async.concatSeries(keys, function (k, cb) {
         var prop = suite[k], _name;
 
         _name = name ? [].concat(name, k) : [k];
-
         _name.toString = function () {
             // fallback for old one
             return this.join(' - ');
         };
 
         if (typeof prop === 'function') {
-            var in_name = false;
+            var in_name = false,
+                in_specific_test = (_name.toString() === opt.testFullSpec) ? true : false;
             for (var i = 0; i < _name.length; i += 1) {
                 if (_name[i] === opt.testspec) {
                     in_name = true;
                 }
             }
-            if (!opt.testspec || in_name) {
+
+            if ((!opt.testFullSpec || in_specific_test) && (!opt.testspec || in_name)) {
                 if (opt.moduleStart) {
                     opt.moduleStart();
                 }
@@ -1772,6 +1808,9 @@ exports.runModule = function (name, mod, opt, callback) {
 
     var _run = false;
     var _moduleStart = options.moduleStart;
+
+    mod = wrapGroup(mod);
+
     function run_once() {
         if (!_run) {
             _run = true;
@@ -1786,6 +1825,9 @@ exports.runModule = function (name, mod, opt, callback) {
         var end = new Date().getTime();
         var assertion_list = types.assertionList(a_list, end - start);
         options.moduleDone(name, assertion_list);
+        if (nodeunit.complete) {
+            nodeunit.complete(name, assertion_list);
+        }
         callback(null, a_list);
     });
 };
@@ -1864,25 +1906,70 @@ var wrapTest = function (setUp, tearDown, fn) {
 
 
 /**
- * Wraps a group of tests with setUp and tearDown functions.
- * Used by testCase.
+ * Returns a serial callback from two functions.
  *
- * @param {Function} setUp
- * @param {Function} tearDown
- * @param {Object} group
+ * @param {Function} funcFirst
+ * @param {Function} funcSecond
  * @api private
  */
 
-var wrapGroup = function (setUp, tearDown, group) {
+var getSerialCallback = function (fns) {
+    if (!fns.length) {
+        return null;
+    }
+    return function (callback) {
+        var that = this;
+        var bound_fns = [];
+        for (var i = 0, len = fns.length; i < len; i++) {
+            (function (j) {
+                bound_fns.push(function () {
+                    return fns[j].apply(that, arguments);
+                });
+            })(i);
+        }
+        return async.series(bound_fns, callback);
+    };
+};
+
+
+/**
+ * Wraps a group of tests with setUp and tearDown functions.
+ * Used by testCase.
+ *
+ * @param {Object} group
+ * @param {Array} setUps - parent setUp functions
+ * @param {Array} tearDowns - parent tearDown functions
+ * @api private
+ */
+
+var wrapGroup = function (group, setUps, tearDowns) {
     var tests = {};
+
+    var setUps = setUps ? setUps.slice(): [];
+    var tearDowns = tearDowns ? tearDowns.slice(): [];
+
+    if (group.setUp) {
+        setUps.push(group.setUp);
+        delete group.setUp;
+    }
+    if (group.tearDown) {
+        tearDowns.unshift(group.tearDown);
+        delete group.tearDown;
+    }
+
     var keys = _keys(group);
+
     for (var i = 0; i < keys.length; i += 1) {
         var k = keys[i];
         if (typeof group[k] === 'function') {
-            tests[k] = wrapTest(setUp, tearDown, group[k]);
+            tests[k] = wrapTest(
+                getSerialCallback(setUps),
+                getSerialCallback(tearDowns),
+                group[k]
+            );
         }
         else if (typeof group[k] === 'object') {
-            tests[k] = wrapGroup(setUp, tearDown, group[k]);
+            tests[k] = wrapGroup(group[k], setUps, tearDowns);
         }
     }
     return tests;
@@ -1890,20 +1977,11 @@ var wrapGroup = function (setUp, tearDown, group) {
 
 
 /**
- * Utility for wrapping a suite of test functions with setUp and tearDown
- * functions.
- *
- * @param {Object} suite
- * @return {Object}
- * @api public
+ * Backwards compatibility for test suites using old testCase API
  */
 
 exports.testCase = function (suite) {
-    var setUp = suite.setUp;
-    var tearDown = suite.tearDown;
-    delete suite.setUp;
-    delete suite.tearDown;
-    return wrapGroup(setUp, tearDown, suite);
+    return suite;
 };
 })(core);
 (function(exports){
@@ -1913,7 +1991,6 @@ exports.testCase = function (suite) {
  * MIT Licensed
  *
  * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
- * You can use @REMOVE_LINE_FOR_BROWSER to remove code from the browser build.
  * Only code on that line will be removed, its mostly to avoid requiring code
  * that is node specific
  */
@@ -1940,7 +2017,9 @@ exports.info = "Browser-based test reporter";
  */
 
 exports.run = function (modules, options) {
-    var start = new Date().getTime();
+    var start = new Date().getTime(), div;
+	options = options || {};
+	div = options.div || document.body;
 
     function setText(el, txt) {
         if ('innerText' in el) {
@@ -1956,7 +2035,7 @@ exports.run = function (modules, options) {
         if (!el) {
             el = document.createElement(tag);
             el.id = id;
-            document.body.appendChild(el);
+            div.appendChild(el);
         }
         return el;
     };

--- a/test/test-fixture.html
+++ b/test/test-fixture.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Test fixture</title>
+  <script>
+    window.__run = true;
+  </script>
+
+</head>
+<body>
+  <script src="../lib/nodeunit.js"></script>
+  <script src="test-fixture.js"></script>
+</body>
+</html>

--- a/test/test-fixture.js
+++ b/test/test-fixture.js
@@ -32,3 +32,6 @@ var fixtureSuite = {
     }
   }
 };
+
+if(typeof exports !== 'undefined') exports.fixtureSuite = fixtureSuite;
+if(window.__run) nodeunit.run(fixtureSuite);

--- a/test/test-fixture.js
+++ b/test/test-fixture.js
@@ -1,7 +1,19 @@
+var obj = {
+  val: 'foo'
+};
+
 var fixtureSuite = {
   passing: {
+    setUp: function(cb) {
+      obj.val = 'bar';
+      cb();
+    },
+    tearDown: function(cb) {
+      obj.val = 'foo';
+      cb();
+    },
     "Ceci nes't pas une test": function(test) {
-        test.notStrictEqual(this, 'une test');
+        test.equal(obj.val, 'bar');
         test.done();
     },
   },


### PR DESCRIPTION
_tldr: I found a bug, i fixed it, I tested the fix. But tests are failing, I don't know why._

While trying to use _karma-nodeunit_ in a project, I got the feeling that `setUp` and `tearDown` did not work properly (they were considered as test-cases). Empirically, I knew that _nodeunit_ lib was buggy: changing `nodeunit.js` by a more recent build fixed the issue.

So, in _karma-nodeunit_:

I modified the tests of karma-nodeunit to make it use `setUp` and `tearDown` in d0b2dc2. As, predicted it failed test suite with a fairly explicit message:

``` sh
.
PhantomJS 1.9.2 (Mac OS X) nodeunit adapter  running a suite of tests should report test results FAILED
    Error: expected 'setUp' to equal 'Ceci nes\'t pas une test' (/Users/alex/Code/karma-nodeunit/node_modules/expect.js/expect.js:99)
PhantomJS 1.9.2 (Mac OS X) nodeunit adapter  running a suite of tests should report test results FAILED
    Error: expected 'setUp' to equal 'Ceci nes\'t pas une test' (/Users/alex/Code/karma-nodeunit/node_modules/expect.js/expect.js:99)
..
```

Then I replaced current _nodeunit_ build with a more recent one in edebd88. But things began to go weird: tests failed.

``` sh
.
PhantomJS 1.9.2 (Mac OS X) nodeunit adapter  running a suite of tests should report test results FAILED
    Error: expected false to equal true (/Users/alex/Code/karma-nodeunit/node_modules/expect.js/expect.js:99)
PhantomJS 1.9.2 (Mac OS X) nodeunit adapter  running a suite of tests should report test results FAILED
    Error: expected false to equal true (/Users/alex/Code/karma-nodeunit/node_modules/expect.js/expect.js:99)
..
```

This is saying that the "passing" fixture test-case actually does not pass.

And indeed doing:

``` diff
--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -32,7 +32,7 @@ describe('nodeunit adapter ', function() {
       sinon.stub(tc, 'result', function(result) {
         expect(result.description).to.equal("Ceci nes't pas une test");
         expect(result.suite).to.be.an('array');
-        expect(result.success).to.be(true);
+        expect(result.success).to.be(false);
         expect(result.log).to.be.an('array');
       });
       runSuite(fixtureSuite.passing, function() {
```

makes test pass.

So, to be sure that this fixture test-case was really failing, I tried to make run "normally" with `nodeunit` in NodeJS and in browser (I commited my test utility stuff in eb54d09): the fixture test-case is perfectly succeeding!

So, my guess is: whether there is a bug in adapter, wether there is a bug in its test suite. Could you help please ?
