### PR TITLE
Update the Readme to use karma-nodeunit as a framework for karma

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Currently supports Karma 0.10.x
 2. Include nodeunit and the karma adapter in your `karma.conf.js`:
 
 ```js
+frameworks = ['nodeunit']
+
 files = [
-  'node_modules/karma-nodeunit/lib/nodeunit.js',
-  'node_modules/karma-nodeunit/lib/adapter.js',
-  'test/*.js'
+  'lib/*.js' // files to test
+  'test/*.js' // test files
 ];
 browsers = ['Chrome'];
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently supports Karma 0.10.x
 2. Include nodeunit and the karma adapter in your `karma.conf.js`:
 
 ```js
-frameworks = ['nodeunit']
+frameworks = ['nodeunit'];
 
 files = [
   'lib/*.js' // files to test


### PR DESCRIPTION
README: when using karma-nodeunit as a karmaframework, you d'ont need to specify karma-nodeunit files.
