### PR TITLE
Include assertion details in chrome error reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - "0.10"
   - "0.8"
 
+before_install:
+  - npm install -g npm
+
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ module.exports = function (config) {
     basePath: '.',
     frameworks: ['mocha'],
     files: [
-      'node_modules/expect.js/expect.js',
+      'node_modules/expect.js/index.js',
       'node_modules/sinon/pkg/sinon.js',
       'lib/nodeunit.js',
       'src/*.js',

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,14 +1,16 @@
 (function(window) {
 
 var formatFailedAssertion = function(assertion) {
+  var stack = assertion.error.stack;
   return (assertion.message || assertion.method || 'no message') +
-    '\n' + (assertion.error.stack || assertion.error);
+    '\n' + (assertion.error) +
+    (stack ? ('\n' + stack) : '');
 };
 
 var createStartFn = function(tc, passedInRunner) {
   var nodeunit = window.nodeunit,
       deferredModules;
-  
+
   // Intercept nodeunit.run in case its called before Karma has started
   nodeunit.run = function(modules) {
     deferredModules = modules;

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.7.x",
-    "grunt-karma": "~0.6.0",
+    "grunt-karma": "~0.8.0",
     "expect.js": "*",
     "sinon": "1.x",
     "mocha": "1.x",
-    "karma-mocha": "~0.1.0"
+    "karma-mocha": "~0.1.0",
+    "karma-firefox-launcher": "*"
   },
   "license": "MIT"
 }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -17,7 +17,8 @@ describe('nodeunit adapter ', function() {
 
     beforeEach(function() {
       runner = window.nodeunit;
-      tc = new Karma(new MockSocket(), {});
+      tc = new Karma(new MockSocket(), {}, window.open,
+          window.navigator, window.location);
       reporter = new (createStartFn(tc))();
     });
 


### PR DESCRIPTION
It looks like somebody already 'fixed' this, but it never got included in lib/adapter.js. I just re-ran `grunt build`
